### PR TITLE
proto: change Flight.proto::doget to accept stream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,4 +93,4 @@ arrow-select = { version = "53.4.0", path = "./arrow-select" }
 arrow-string = { version = "53.4.0", path = "./arrow-string" }
 parquet = { version = "53.4.0", path = "./parquet", default-features = false }
 
-chrono = { version = "0.4.34", default-features = false, features = ["clock"] }
+chrono = { version = ">= 0.4.34, < 0.4.40", default-features = false, features = ["clock"] }

--- a/arrow-flight/examples/server.rs
+++ b/arrow-flight/examples/server.rs
@@ -75,7 +75,7 @@ impl FlightService for FlightServiceImpl {
 
     async fn do_get(
         &self,
-        _request: Request<Ticket>,
+        _request: Request<Streaming<Ticket>>,
     ) -> Result<Response<Self::DoGetStream>, Status> {
         Err(Status::unimplemented("Implement do_get"))
     }

--- a/arrow-flight/src/decode.rs
+++ b/arrow-flight/src/decode.rs
@@ -53,7 +53,11 @@ use crate::error::{FlightError, Result};
 /// # unimplemented!();
 ///
 /// let request = tonic::Request::new(
-///   Ticket { ticket: Bytes::new() }
+///   futures::stream::once(
+///     std::future::ready(
+///       Ticket { ticket: Bytes::new() }
+///     )
+///   )
 /// );
 ///
 /// // Get a stream of FlightData;

--- a/arrow-flight/src/sql/client.rs
+++ b/arrow-flight/src/sql/client.rs
@@ -296,9 +296,9 @@ impl FlightSqlServiceClient<Channel> {
     /// Given a flight ticket, request to be sent the stream. Returns record batch stream reader
     pub async fn do_get(
         &mut self,
-        ticket: impl IntoRequest<Ticket>,
+        ticket: impl tonic::IntoStreamingRequest<Message = Ticket>,
     ) -> Result<FlightRecordBatchStream, ArrowError> {
-        let req = self.set_request_headers(ticket.into_request())?;
+        let req = self.set_request_headers(ticket.into_streaming_request())?;
 
         let (md, response_stream, _ext) = self
             .flight_client

--- a/arrow-integration-testing/src/flight_server_scenarios/auth_basic_proto.rs
+++ b/arrow-integration-testing/src/flight_server_scenarios/auth_basic_proto.rs
@@ -113,7 +113,7 @@ impl FlightService for AuthBasicProtoScenarioImpl {
 
     async fn do_get(
         &self,
-        request: Request<Ticket>,
+        request: Request<Streaming<Ticket>>,
     ) -> Result<Response<Self::DoGetStream>, Status> {
         self.check_auth(request.metadata()).await?;
         Err(Status::unimplemented("Not yet implemented"))

--- a/arrow-integration-testing/src/flight_server_scenarios/integration_test.rs
+++ b/arrow-integration-testing/src/flight_server_scenarios/integration_test.rs
@@ -105,9 +105,13 @@ impl FlightService for FlightServiceImpl {
 
     async fn do_get(
         &self,
-        request: Request<Ticket>,
+        request: Request<Streaming<Ticket>>,
     ) -> Result<Response<Self::DoGetStream>, Status> {
-        let ticket = request.into_inner();
+        let mut ticket = request.into_inner();
+        let ticket = ticket
+            .next()
+            .await
+            .ok_or_else(|| Status::invalid_argument("Must have a ticket."))??;
 
         let key = str::from_utf8(&ticket.ticket)
             .map_err(|e| Status::invalid_argument(format!("Invalid ticket: {e:?}")))?;

--- a/arrow-integration-testing/src/flight_server_scenarios/middleware.rs
+++ b/arrow-integration-testing/src/flight_server_scenarios/middleware.rs
@@ -70,7 +70,7 @@ impl FlightService for MiddlewareScenarioImpl {
 
     async fn do_get(
         &self,
-        _request: Request<Ticket>,
+        _request: Request<Streaming<Ticket>>,
     ) -> Result<Response<Self::DoGetStream>, Status> {
         Err(Status::unimplemented("Not yet implemented"))
     }

--- a/format/Flight.proto
+++ b/format/Flight.proto
@@ -105,7 +105,7 @@
     * more streams where each stream can be retrieved using a separate opaque
     * ticket that the flight service uses for managing a collection of streams.
     */
-   rpc DoGet(Ticket) returns (stream FlightData) {}
+   rpc DoGet(stream Ticket) returns (stream FlightData) {}
  
    /*
     * Push a stream to the flight service associated with a particular


### PR DESCRIPTION
For many cases passing a ticket into doget method is OK, but if the schema is large enough, the ticket becomes heavy. It's not a big problem itself though. It does become a problem, when used gRPC connection is overloaded. The default mechanism to handle that is to put waiting requests into a queue and take them one-by-one once the connection is ready. If each ticket is heavy, and there are many of such incoming requests, then the queue starts utilizing noticeable amount of memory.

The patch allows to customize the discribed behavior. Instead of consuming a potentially heavy ticket, doget accepts a stream over the ticket. The default behavior is the same as before, but when needed the stream can be customized such way that life time of its element is controlled outside of the stream (e. g. it can be pinned to the parent future to be expired when the future drops). Moreover, the stream itself may become lightweight because it isn't required to consume the ticket anymore, instead it may contain a weak pointer, receiver, or use other technique of promising.